### PR TITLE
fix: replace other max_recs

### DIFF
--- a/swift_vo/objobssap/api.py
+++ b/swift_vo/objobssap/api.py
@@ -53,7 +53,7 @@ async def objvissap(
         t_min=time.t_min,
         t_max=time.t_max,
         min_obs=min_obs,
-        max_rec=MAXREC,
+        maxrec=MAXREC,
         upload=UPLOAD,
     )
     await vo.query()

--- a/swift_vo/objobssap/service.py
+++ b/swift_vo/objobssap/service.py
@@ -17,7 +17,7 @@ class ObjObsSAPService:
     This class is the service class for the ObjObsSAP service.
     """
 
-    def __init__(self, s_ra, s_dec, t_min, t_max, min_obs, max_rec=None, upload=None):
+    def __init__(self, s_ra, s_dec, t_min, t_max, min_obs, maxrec=None, upload=None):
         """
         This method initializes the service class.
         """
@@ -26,7 +26,7 @@ class ObjObsSAPService:
         self.t_min = Time(t_min, format="mjd").datetime
         self.t_max = Time(t_max, format="mjd").datetime
         self.min_obs = min_obs
-        self.max_rec = max_rec
+        self.maxrec = maxrec
         self.upload = upload
         self.windows = []
 
@@ -34,7 +34,7 @@ class ObjObsSAPService:
         """
         This method queries the ObjObsSAP service.
         """
-        if self.max_rec != 0:
+        if self.maxrec != 0:
             vis_windows = await asyncify(VisQuery)(
                 ra=self.s_ra, dec=self.s_dec, begin=self.t_min, end=self.t_max, hires=True
             )
@@ -43,8 +43,8 @@ class ObjObsSAPService:
                 for e in vis_windows.entries
                 if e.length.total_seconds() >= self.min_obs
             ]
-        if self.max_rec is not None:
-            self.windows = self.windows[: self.max_rec]
+        if self.maxrec is not None:
+            self.windows = self.windows[: self.maxrec]
 
     async def vo_format(self) -> str:
         """
@@ -82,8 +82,8 @@ class ObjObsSAPService:
         resource.infos.append(Info(name="TIME", value=f"{Time(self.t_min).mjd}/{Time(self.t_max).mjd}"))
         if self.min_obs is not None and self.min_obs > 0:
             resource.infos.append(Info(name="MIN_OBS", value=str(self.min_obs)))
-        if self.max_rec is not None:
-            resource.infos.append(Info(name="MAX_REC", value=str(self.max_rec)))
+        if self.maxrec is not None:
+            resource.infos.append(Info(name="MAXREC", value=str(self.maxrec)))
         if self.upload is not None:
             resource.infos.append(Info(name="UPLOAD", value=str(self.upload)))
 
@@ -167,7 +167,7 @@ datatype="float" unit="d"/>
 <FIELD name="t_observability"
 utype="Char.TimeAxis.Coverage.Support.Extent"
 ucd="time.duration" datatype="float" unit="s"/>\n"""
-        if self.max_rec != 0:
+        if self.maxrec != 0:
             vo += "<DATA>\n"
             vo += "<TABLEDATA>\n"
 

--- a/tests/swift_vo/test_service.py
+++ b/tests/swift_vo/test_service.py
@@ -34,10 +34,10 @@ class TestObjObsSAPService:
         service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500)
         assert service.min_obs == 1500
 
-    def test_max_rec_default_initialization(self):
-        """Test the default initialization of max_rec parameter."""
+    def test_maxrec_default_initialization(self):
+        """Test the default initialization of maxrec parameter."""
         service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500)
-        assert service.max_rec is None
+        assert service.maxrec is None
 
     def test_upload_default_initialization(self):
         """Test the default initialization of upload parameter."""
@@ -49,10 +49,10 @@ class TestObjObsSAPService:
         service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500)
         assert service.windows == []
 
-    def test_max_rec_optional_initialization(self):
-        """Test the optional initialization of max_rec parameter."""
-        service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500, max_rec=100)
-        assert service.max_rec == 100
+    def test_maxrec_optional_initialization(self):
+        """Test the optional initialization of maxrec parameter."""
+        service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500, maxrec=100)
+        assert service.maxrec == 100
 
     def test_upload_optional_initialization(self):
         """Test the optional initialization of upload parameter."""
@@ -182,21 +182,21 @@ class TestObjObsSAPService:
     @pytest.mark.asyncio
     async def test_vo_format_hard_coded_no_data_empty_windows(self):
         """Test if vo_format_hard_coded has no DATA tag with empty windows."""
-        service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500, max_rec=0)
+        service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500, maxrec=0)
         result = await service.vo_format_hard_coded()
         assert "<DATA>" not in result
 
     @pytest.mark.asyncio
     async def test_vo_format_hard_coded_no_tabledata_empty_windows(self):
         """Test if vo_format_hard_coded has no TABLEDATA tag with empty windows."""
-        service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500, max_rec=0)
+        service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500, maxrec=0)
         result = await service.vo_format_hard_coded()
         assert "<TABLEDATA>" not in result
 
     @pytest.mark.asyncio
     async def test_vo_format_hard_coded_no_tr_empty_windows(self):
         """Test if vo_format_hard_coded has no TR tag with empty windows."""
-        service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500, max_rec=0)
+        service = ObjObsSAPService(10.5, 20.3, 60000, 60001, 1500, maxrec=0)
         result = await service.vo_format_hard_coded()
         assert "<TR>" not in result
 


### PR DESCRIPTION
This pull request standardizes the naming of the `maxrec` parameter across the codebase, replacing all instances of `max_rec` with `maxrec` for consistency. The changes affect both the implementation and the associated tests to ensure uniform usage.

Parameter renaming for consistency:

* Renamed the `max_rec` parameter and all related attributes to `maxrec` in the `ObjObsSAPService` class, its methods, and its usage throughout `swift_vo/objobssap/service.py` and `swift_vo/objobssap/api.py`. [[1]](diffhunk://#diff-760ac60082fb33567ab146fba3fe52ffeeffaef067988ddf78eeed337275ffa6L20-R20) [[2]](diffhunk://#diff-760ac60082fb33567ab146fba3fe52ffeeffaef067988ddf78eeed337275ffa6L29-R37) [[3]](diffhunk://#diff-760ac60082fb33567ab146fba3fe52ffeeffaef067988ddf78eeed337275ffa6L46-R47) [[4]](diffhunk://#diff-760ac60082fb33567ab146fba3fe52ffeeffaef067988ddf78eeed337275ffa6L85-R86) [[5]](diffhunk://#diff-760ac60082fb33567ab146fba3fe52ffeeffaef067988ddf78eeed337275ffa6L170-R170) [[6]](diffhunk://#diff-ac4598c2b99ee50b7124c7a2d4027f4a18f96c8b18990a5a01c5b5a405afdd37L56-R56)

Test updates for parameter renaming:

* Updated all test cases in `tests/swift_vo/test_service.py` to use `maxrec` instead of `max_rec`, including function names, parameter usage, and assertions. [[1]](diffhunk://#diff-050bd31ccdac1e6f47f0d10b9523322d78159ed517521544f1d603a9be16dc59L37-R40) [[2]](diffhunk://#diff-050bd31ccdac1e6f47f0d10b9523322d78159ed517521544f1d603a9be16dc59L52-R55) [[3]](diffhunk://#diff-050bd31ccdac1e6f47f0d10b9523322d78159ed517521544f1d603a9be16dc59L185-R199)