### PR TITLE
fix: move pytest-asyncio dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "gunicorn>=23.0.0",
     "uvicorn>=0.34.0",
     "asyncer>=0.0.8",
-    "pytest-asyncio>=0.26.0",
     "h11>=0.16.0",
 ]
 
@@ -37,6 +36,7 @@ dev = [
     "pytest-cov", # Used to report total code coverage
     "ruff",       # Used for static linting of files
     "ipykernel>=6.0.0,<7.0.0",
+    "pytest-asyncio>=0.26.0",
 ]
 
 [build-system]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -248,8 +248,6 @@ numpy==2.2.4
     #   pandas
     #   pyerfa
     #   swifttools
-overrides==7.7.0
-    # via jupyter-server
 packaging==25.0
     # via
     #   astropy
@@ -441,15 +439,12 @@ types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.13.0
     # via
-    #   anyio
     #   beautifulsoup4
     #   fastapi
     #   mypy
     #   pydantic
     #   pydantic-core
-    #   referencing
     #   rich-toolkit
-    #   starlette
     #   typer
     #   typing-inspection
 typing-inspection==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,8 +61,6 @@ idna==3.10
     #   email-validator
     #   httpx
     #   requests
-iniconfig==2.1.0
-    # via pytest
 jinja2==3.1.6
     # via fastapi
 jmespath==1.0.1
@@ -85,11 +83,8 @@ packaging==25.0
     # via
     #   astropy
     #   gunicorn
-    #   pytest
 pandas==2.2.3
     # via swifttools
-pluggy==1.5.0
-    # via pytest
 pyasn1==0.4.8
     # via
     #   python-jose
@@ -102,10 +97,6 @@ pyerfa==2.0.1.5
     # via astropy
 pygments==2.19.1
     # via rich
-pytest==8.3.5
-    # via pytest-asyncio
-pytest-asyncio==0.26.0
-    # via swift-vo (pyproject.toml)
 python-dateutil==2.9.0.post0
     # via
     #   botocore
@@ -152,12 +143,10 @@ typer==0.16.0
     # via fastapi-cli
 typing-extensions==4.13.0
     # via
-    #   anyio
     #   fastapi
     #   pydantic
     #   pydantic-core
     #   rich-toolkit
-    #   starlette
     #   typer
     #   typing-inspection
 typing-inspection==0.4.0


### PR DESCRIPTION
This pull request makes minor adjustments to the project's dependency management. The main change is moving the `pytest-asyncio` package from the main dependencies list to the development dependencies section in `pyproject.toml`, ensuring it's only installed for development and testing purposes. Additionally, some unused or commented references in `requirements-dev.txt` have been cleaned up.

Dependency management improvements:

* Moved `pytest-asyncio` from the main `dependencies` list to the `dev` dependencies in `pyproject.toml`, so it's only installed for development and testing. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L23) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R39)

Development requirements cleanup:

* Removed the `overrides` package and several commented references in `requirements-dev.txt` to keep the file tidy and focused on actual requirements. [[1]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL251-L252) [[2]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL444-L452)