### PR TITLE
Time should not be a required parameter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         description: Verify that pyproject.toml adheres to the established schema.
     # Verify that GitHub workflows are well formed
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.34.0
+    rev: 0.34.1
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]

--- a/swift_vo/objobssap/api.py
+++ b/swift_vo/objobssap/api.py
@@ -16,7 +16,10 @@ def parse_pos(POS: str = Query(..., description="Position in 'RA,DEC' format")) 
 def parse_time(
     TIME: str | None = Query(
         default=None,
-        description="Time range in 'T_MIN/T_MAX' format. Defaults to current date through 7 days from now if not provided.",
+        description=(
+            "Time range in 'T_MIN/T_MAX' format. Defaults to current date through"
+            " 7 days from now if not provided."
+        ),
     ),
 ) -> VOTimeRange:
     """Parses the time string into a VOTimeRange object."""


### PR DESCRIPTION
This pull request introduces a small update to the pre-commit configuration and improves the flexibility of the `parse_time` function in the `swift_vo/objobssap/api.py` module. The most notable change is the enhancement of the time parsing logic to provide sensible defaults when a time range is not specified.

**Pre-commit configuration:**

* Updated the `check-jsonschema` pre-commit hook version from `0.34.0` to `0.34.1` in `.pre-commit-config.yaml` for improved workflow validation.

**API improvements:**

* Enhanced the `parse_time` function in `swift_vo/objobssap/api.py` to accept an optional `TIME` parameter. If not provided, it now defaults to the current date through 7 days from now, improving usability for clients who do not specify a time range.
* Added import of `astropy.time.Time` to support the new default time logic in `parse_time`.
* Fixed import order and location for `ObjObsSAPService` for clarity and consistency.