### PR TITLE
Escape html special characters in xml output

### DIFF
--- a/swift_vo/objobssap/service.py
+++ b/swift_vo/objobssap/service.py
@@ -1,4 +1,3 @@
-import re
 from datetime import UTC, datetime
 from io import BytesIO
 


### PR DESCRIPTION
Make sure HTML special characters are escaped in XML output.

Resolves #80 