### PR TITLE
fix: allow URL parameters to be mixed case

### DIFF
--- a/.github/workflows/pre-commit-ci.yml
+++ b/.github/workflows/pre-commit-ci.yml
@@ -25,8 +25,8 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install .[dev]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install --retries 5 --timeout 60 -r requirements-dev.txt
+        python -m pip install --no-deps -e .
     - uses: pre-commit/action@v3.0.1
       with:
         extra_args: --all-files --verbose

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -32,8 +32,8 @@ jobs:
       run: |
         sudo apt-get update
         python -m pip install --upgrade pip
-        pip install -e .[dev]
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        python -m pip install --retries 5 --timeout 60 -r requirements-dev.txt
+        python -m pip install --no-deps -e .
     - name: List dependencies
       run: |
         pip list

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -26,8 +26,8 @@ jobs:
         run: |
           sudo apt-get update
           python -m pip install --upgrade pip
-          pip install -e .[dev]
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          python -m pip install --retries 5 --timeout 60 -r requirements-dev.txt
+          python -m pip install --no-deps -e .
       - name: Run unit tests with pytest
         run: |
           python -m pytest --cov=swift_vo --cov-report=xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,20 +34,20 @@ repos:
         args: ['--maxkb=500']
     # Verify that pyproject.toml is well formed
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.24.1
+    rev: v0.25
     hooks:
       - id: validate-pyproject
         name: Validate pyproject.toml
         description: Verify that pyproject.toml adheres to the established schema.
     # Verify that GitHub workflows are well formed
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.36.1
+    rev: 0.37.1
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.14
+    rev: v0.15.11
     hooks:
       - id: ruff-check
         name: Lint code using ruff; sort and organize imports 
@@ -55,7 +55,7 @@ repos:
         args: ["--fix"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.14.14
+    rev: v0.15.11
     hooks:
       - id: ruff-format
         name: Format code using ruff

--- a/swift_vo/base/api.py
+++ b/swift_vo/base/api.py
@@ -1,3 +1,5 @@
+from urllib.parse import parse_qsl, urlencode
+
 from fastapi import FastAPI, Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -16,6 +18,18 @@ app = FastAPI(
 )
 
 
+def _normalize_query_string(query_string: bytes) -> bytes:
+    """Lowercase query parameter names while preserving their values."""
+    if not query_string:
+        return query_string
+
+    normalized_items = [
+        (key.lower(), value)
+        for key, value in parse_qsl(query_string.decode("latin-1"), keep_blank_values=True)
+    ]
+    return urlencode(normalized_items, doseq=True).encode("latin-1")
+
+
 class CaseInsensitiveMiddleware(BaseHTTPMiddleware):
     """
     Middleware to convert all request paths to lowercase.
@@ -27,8 +41,8 @@ class CaseInsensitiveMiddleware(BaseHTTPMiddleware):
         """
         Dispatch the request and convert the path to lowercase.
         """
-        # Convert path to lowercase
         request.scope["path"] = request.scope["path"].lower()
+        request.scope["query_string"] = _normalize_query_string(request.scope.get("query_string", b""))
         response = await call_next(request)
         return response
 

--- a/tests/swift_vo/test_api.py
+++ b/tests/swift_vo/test_api.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
@@ -94,4 +96,17 @@ class TestObjObsSAP:
     def test_default_time(self, valid_pos, valid_min_obs):
         """Test that the endpoint doesn't require TIME."""
         response = client.get("/ObjObsSAP/query", params={"pos": valid_pos, "min_obs": valid_min_obs})
+        assert response.status_code == 200
+
+    def test_endpoint_accepts_mixed_case_query_parameters(self, valid_pos, valid_time, valid_min_obs):
+        """Test that query parameter names are handled case-insensitively."""
+        query_string = (
+            f"POS={quote(valid_pos)}&time={quote(valid_time)}&Min_Obs={quote(valid_min_obs)}&MAXREC=1"
+        )
+        response = client.get(f"/ObjObsSAP/query?{query_string}")
+        assert response.status_code == 200
+
+    def test_endpoint_accepts_uppercase_default_time_parameters(self, valid_pos, valid_min_obs):
+        """Test that defaulted parameters still work with uppercase query names."""
+        response = client.get(f"/ObjObsSAP/query?POS={quote(valid_pos)}&MIN_OBS={quote(valid_min_obs)}")
         assert response.status_code == 200


### PR DESCRIPTION
## Change Description

Allow URL parameters to be mixed case, i.e. case insensitive, as required by VO specs.

Resolves #115 

## Solution Description

Updated middleware.


