### PR TITLE
fix: don't allow calculation of visibility > 30 days into future

### DIFF
--- a/swift_vo/constants.py
+++ b/swift_vo/constants.py
@@ -1,3 +1,4 @@
 VO_SERVER = "www.swift.psu.edu"
 VO_ROOT_PATH = "/vo"
 OBJOBSSAP_DEFAULT_LENGTH = 7  # days
+T_MAX_HARD_LIMIT_DELTA = 30  # days to add to current date for hard limit on future visibility

--- a/swift_vo/objobssap/service.py
+++ b/swift_vo/objobssap/service.py
@@ -12,6 +12,8 @@ from astropy.time import Time  # type: ignore[import-untyped]
 from asyncer import asyncify
 from swifttools.swift_too import VisQuery  # type: ignore[import-untyped]
 
+from ..constants import T_MAX_HARD_LIMIT_DELTA
+
 
 class ObjObsSAPService:
     """
@@ -25,7 +27,12 @@ class ObjObsSAPService:
         self.s_ra = s_ra
         self.s_dec = s_dec
         self.t_min = Time(t_min, format="mjd").datetime
-        self.t_max = Time(t_max, format="mjd").datetime
+        requested_t_max = Time(t_max, format="mjd").datetime
+        hard_limit_mjd = int(Time.now().mjd) + T_MAX_HARD_LIMIT_DELTA
+        hard_limit = Time(hard_limit_mjd, format="mjd").datetime
+        self.t_max_hard_limit_used = requested_t_max > hard_limit
+        self.t_max = min(requested_t_max, hard_limit)
+        self.t_max_hard_limit = hard_limit_mjd
         self.min_obs = min_obs
         self.maxrec = maxrec
         self.upload = upload
@@ -88,6 +95,8 @@ class ObjObsSAPService:
 
         resource.infos.append(Info(name="POS", value=f"{self.s_ra},{self.s_dec}"))
         resource.infos.append(Info(name="TIME", value=f"{Time(self.t_min).mjd}/{Time(self.t_max).mjd}"))
+        if self.t_max_hard_limit_used:
+            resource.infos.append(Info(name="T_MAX_HARD_LIMIT", value=str(self.t_max_hard_limit)))
         if self.min_obs is not None and self.min_obs > 0:
             resource.infos.append(Info(name="MIN_OBS", value=str(self.min_obs)))
         if self.maxrec is not None:

--- a/tests/swift_vo/test_service.py
+++ b/tests/swift_vo/test_service.py
@@ -3,6 +3,9 @@ from datetime import datetime
 import pytest  # type: ignore[import-untyped]
 from astropy.time import Time  # type: ignore[import-untyped]
 
+from swift_vo.constants import T_MAX_HARD_LIMIT_DELTA
+from swift_vo.objobssap.service import ObjObsSAPService
+
 
 class TestObjObsSAPService:
     """Test class for ObjObsSAPService which validates initialization and type conversion of parameters."""
@@ -94,6 +97,22 @@ class TestObjObsSAPService:
         """Test if t_validity field is defined in XML."""
         result = await service_with_windows.vo_format()
         assert 'name="t_validity"' in result
+
+    def test_t_max_hard_limit_delta_constant(self):
+        """Test the hard limit delta constant is defined and positive."""
+        assert isinstance(T_MAX_HARD_LIMIT_DELTA, int)
+        assert T_MAX_HARD_LIMIT_DELTA > 0
+
+    @pytest.mark.asyncio
+    async def test_t_max_hard_limit_info_in_xml_when_clamped(self):
+        """Test that a hard limit INFO entry is included when the request is clamped."""
+        now_mjd = int(Time.now().mjd)
+        requested_t_max = now_mjd + T_MAX_HARD_LIMIT_DELTA + 100
+        service = ObjObsSAPService(10.5, 20.3, now_mjd, requested_t_max, 1500)
+        result = await service.vo_format()
+        assert 'name="T_MAX_HARD_LIMIT"' in result
+        assert f'name="T_MAX_HARD_LIMIT" value="{service.t_max_hard_limit}"' in result
+        assert f'name="TIME" value="{Time(service.t_min).mjd}/{Time(service.t_max).mjd}"' in result
 
     @pytest.mark.asyncio
     async def test_field_count_in_xml(self, service_with_windows, expected_fields):


### PR DESCRIPTION
## Change Description

Defines a limit to how far in the future visibilities can be calculated, which is reported in the form of:
```xml
<INFO name="T_MAX_HARD_LIMIT" value="61231"/>
```
in the VOTable header if the requested range is further into the future. 

Resolves #118 